### PR TITLE
Task/added cancellation support

### DIFF
--- a/src/CSESoftware.Repository.EntityFrameworkCore.TestProject/CSESoftware.Repository.EntityFrameworkCore.TestProject.csproj
+++ b/src/CSESoftware.Repository.EntityFrameworkCore.TestProject/CSESoftware.Repository.EntityFrameworkCore.TestProject.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="CSESoftware.Core" Version="2.0.0" />
-    <PackageReference Include="CSESoftware.Repository" Version="2.1.1" />
+    <PackageReference Include="CSESoftware.Repository" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />

--- a/src/CSESoftware.Repository.EntityFrameworkCore/CSESoftware.Repository.EntityFrameworkCore.csproj
+++ b/src/CSESoftware.Repository.EntityFrameworkCore/CSESoftware.Repository.EntityFrameworkCore.csproj
@@ -5,8 +5,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>CSESoftware.Repository.EntityFrameworkCore</PackageId>
     <Authors>CSE Software, Inc.</Authors>
-    <Copyright>2021 CSE Software, Inc.</Copyright>
-    <Version>2.1.1</Version>
+    <Copyright>2022 CSE Software, Inc.</Copyright>
+    <Version>2.2.0-beta1</Version>
     <PackageIcon>packageIcon.png</PackageIcon>
     <PackageIconUrl />
     <Description>The Entity Framework Core implementation of CSESoftware.Repository.</Description>
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="CSESoftware.Core" Version="2.0.0" />
-    <PackageReference Include="CSESoftware.Repository" Version="2.1.1" />
+    <PackageReference Include="CSESoftware.Repository" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.5" />
   </ItemGroup>

--- a/src/CSESoftware.Repository.EntityFrameworkCore/CSESoftware.Repository.EntityFrameworkCore.csproj
+++ b/src/CSESoftware.Repository.EntityFrameworkCore/CSESoftware.Repository.EntityFrameworkCore.csproj
@@ -6,7 +6,7 @@
     <PackageId>CSESoftware.Repository.EntityFrameworkCore</PackageId>
     <Authors>CSE Software, Inc.</Authors>
     <Copyright>2022 CSE Software, Inc.</Copyright>
-    <Version>2.2.0-beta1</Version>
+    <Version>2.2.0</Version>
     <PackageIcon>packageIcon.png</PackageIcon>
     <PackageIconUrl />
     <Description>The Entity Framework Core implementation of CSESoftware.Repository.</Description>

--- a/src/CSESoftware.Repository.EntityFrameworkCore/ReadOnlyRepository.cs
+++ b/src/CSESoftware.Repository.EntityFrameworkCore/ReadOnlyRepository.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace CSESoftware.Repository.EntityFrameworkCore
@@ -59,7 +60,7 @@ namespace CSESoftware.Repository.EntityFrameworkCore
         public virtual Task<List<TEntity>> GetAllAsync<TEntity>(IQuery<TEntity> filter)
             where TEntity : class, IEntity
         {
-            return GetQueryable(filter).ToListAsync();
+            return GetQueryable(filter).ToListAsync(filter?.CancellationToken ?? CancellationToken.None);
         }
 
         public virtual Task<List<TEntity>> GetAllAsync<TEntity>(Expression<Func<TEntity, bool>> filter = null)
@@ -71,7 +72,7 @@ namespace CSESoftware.Repository.EntityFrameworkCore
         public virtual Task<TEntity> GetFirstAsync<TEntity>(IQuery<TEntity> filter)
             where TEntity : class, IEntity
         {
-            return GetQueryable(filter).FirstOrDefaultAsync();
+            return GetQueryable(filter).FirstOrDefaultAsync(filter?.CancellationToken ?? CancellationToken.None);
         }
 
         public virtual Task<TEntity> GetFirstAsync<TEntity>(Expression<Func<TEntity, bool>> filter = null)
@@ -85,7 +86,7 @@ namespace CSESoftware.Repository.EntityFrameworkCore
         public virtual Task<int> GetCountAsync<TEntity>(IQuery<TEntity> filter)
             where TEntity : class, IEntity
         {
-            return GetQueryable(filter).CountAsync();
+            return GetQueryable(filter).CountAsync(filter?.CancellationToken ?? CancellationToken.None);
         }
 
         public virtual Task<int> GetCountAsync<TEntity>(Expression<Func<TEntity, bool>> filter = null)
@@ -97,7 +98,7 @@ namespace CSESoftware.Repository.EntityFrameworkCore
         public virtual Task<bool> GetExistsAsync<TEntity>(IQuery<TEntity> filter)
             where TEntity : class, IEntity
         {
-            return GetQueryable(filter).AnyAsync();
+            return GetQueryable(filter).AnyAsync(filter?.CancellationToken ?? CancellationToken.None);
         }
 
         public virtual Task<bool> GetExistsAsync<TEntity>(Expression<Func<TEntity, bool>> filter = null)
@@ -108,12 +109,12 @@ namespace CSESoftware.Repository.EntityFrameworkCore
 
         public virtual Task<List<TOut>> GetAllWithSelectAsync<TEntity, TOut>(IQueryWithSelect<TEntity, TOut> filter = null) where TEntity : class, IEntity
         {
-            return GetQueryableSelect(filter).ToListAsync();
+            return GetQueryableSelect(filter).ToListAsync(filter?.CancellationToken ?? CancellationToken.None);
         }
 
         public Task<TOut> GetFirstWithSelectAsync<TEntity, TOut>(IQueryWithSelect<TEntity, TOut> filter = null) where TEntity : class, IEntity
         {
-            return GetQueryableSelect(filter).FirstOrDefaultAsync();
+            return GetQueryableSelect(filter).FirstOrDefaultAsync(filter?.CancellationToken ?? CancellationToken.None);
         }
     }
 }

--- a/src/CSESoftware.Repository.EntityFrameworkCore/Repository.cs
+++ b/src/CSESoftware.Repository.EntityFrameworkCore/Repository.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using CSESoftware.Core.Entity;
 using Microsoft.EntityFrameworkCore;
@@ -85,9 +86,9 @@ namespace CSESoftware.Repository.EntityFrameworkCore
             Context.Set<TEntity>().RemoveRange(Context.Set<TEntity>().Where(filter));
         }
 
-        public virtual async Task SaveAsync()
+        public virtual async Task SaveAsync(CancellationToken? cancellationToken = null)
         {
-            await Context.SaveChangesAsync();
+            await Context.SaveChangesAsync(cancellationToken ?? CancellationToken.None);
             DetachAllEntities();
         }
 


### PR DESCRIPTION
Made use of CancellationTokens built into the IQuery used within IReadOnlyRepository to allow for cancellation of asynchronous database queries. Additionally made use of 2.2.0 updates to Repository to accept CancellationTokens into the SaveAsync call in order to cancel write/delete operations.